### PR TITLE
Pass socket data back after getting session

### DIFF
--- a/session.socket.io.js
+++ b/session.socket.io.js
@@ -22,7 +22,7 @@ function SessionSockets(io, sessionStore, cookieParser, key) {
       var sessionLookupMethod = sessionStore.load || sessionStore.get;
       sessionLookupMethod.call(sessionStore, findCookie(socket.handshake), function (storeErr, session) {
         var err = resolveErr(parseErr, storeErr, session);
-        callback(err, session);
+        callback(err, session, socket);
       });
     });
   };


### PR DESCRIPTION
Passing the socket data back after getting a session helps to loop through multiple sessions when searching for the socket of a particular user. While there are other ways to avoid this, passing socket data back is very inexpensive.

Broken example before pull request
```javascript
var something = function(userID) {
    var clients_in_the_room = io.sockets.adapter.rooms['room1'],
        clientKeys = Object.keys(clients_in_the_room),
    for (var i=0;i<clientKeys.length;i++) {
        sessionSockets.getSession(io.sockets.connected[clientKeys[i]], function (err, session) {
            var clientSocket = io.sockets.connected[clientKeys[i]]; // i could actually be another number by now
            if(session.user == userID) {
                clientSocket.emit('do-something');                      

                return;
            }
        });	
    }
}
```

Example after request
```javascript
var something = function(userID) {
    var clients_in_the_room = io.sockets.adapter.rooms['room1'],
        clientKeys = Object.keys(clients_in_the_room),
    for (var i=0;i<clientKeys.length;i++) {
        sessionSockets.getSession(io.sockets.connected[clientKeys[i]], function (err, session, socket) {
            if(session.user == userID) {
                socket.emit('do-something');                      

                return;
                
            }
        });	
    }
}
```